### PR TITLE
add database.yml as configuration for database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,7 @@
+development:
+  adapter: sqlite3
+  database: db/development.sqlite3
+
+test:
+  adapter: sqlite3
+  database: db/test.sqlite3


### PR DESCRIPTION
I have an issue when running **rake db:create** which is

`ActiveRecord::AdapterNotSpecified: The 'development' database is not configured for the 'default_env' environment.`

So I'd solved it by adding a configuration file, namely database.yml.